### PR TITLE
wrong method calls fixed

### DIFF
--- a/lib/tanakai/base.rb
+++ b/lib/tanakai/base.rb
@@ -159,7 +159,7 @@ module Tanakai
       if args.present?
         spider.public_send(handler, *args)
       elsif request.present?
-        spider.request_to(handler, request)
+        spider.request_to(handler, **request)
       else
         spider.public_send(handler)
       end
@@ -201,7 +201,7 @@ module Tanakai
       visited = delay ? browser.visit(url, delay: delay) : browser.visit(url)
       return unless visited
 
-      public_send(handler, browser.current_response(response_type), { url: url, data: data })
+      public_send(handler, browser.current_response(response_type), url: url, data: data)
     end
 
     def console(response = nil, url: nil, data: {})


### PR DESCRIPTION
When the parser! I found that the way in which the parameters are sent seems to be wrong, I leave this PR, tell me what you think; I don't know if I'm wrong, or it's really a bug. NOTE: I can't find an issues section, that's why I'm posting it here:

#### Before:
```
class ExampleSpider < Tanakai::Base
  @name = "example_spider"
  @engine = :mechanize
  @start_urls = ["https://example.com/"]

  def parse(response, url:, data: {})
    title = response.xpath("//title").text.squish
  end
end

ExampleSpider.parse!(:parse, url: "https://example.com/")

Error on `ArgumentError: missing keyword: :url`
```
<img width="992" alt="Screen Shot 2022-12-26 at 11 02 28 AM" src="https://user-images.githubusercontent.com/6793843/209566629-84ebf09f-dcbf-49eb-9524-3691a2990770.png">

#### After:
<img width="1434" alt="Screen Shot 2022-12-26 at 11 16 12 AM" src="https://user-images.githubusercontent.com/6793843/209566903-fdd9c93a-3ced-4184-bd38-9d19a8be7da4.png">

