### PR TITLE
Update: Ruby 3.2: `File::exists?` removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,7 +130,6 @@
 * Fix Mechanize::Driver#proxy (there was a bug while using proxy for mechanize engine without authorization)
 * Fix requests retries logic
 
-
 ## 1.0.1
 * Add missing `logger` method to pipeline
 * Fix `set_proxy` in Mechanize and Poltergeist builders

--- a/lib/tanakai/base/saver.rb
+++ b/lib/tanakai/base/saver.rb
@@ -42,7 +42,7 @@ module Tanakai
       def save_to_json(item)
         data = JSON.generate([item])
 
-        if @index > 1 || append && File.exists?(path)
+        if @index > 1 || append && File.exist?(path)
           file_content = File.read(path).sub(/\}\]\Z/, "\}\,")
           File.open(path, "w") do |f|
             f.write(file_content + data.sub(/\A\[/, ""))
@@ -55,7 +55,7 @@ module Tanakai
       def save_to_pretty_json(item)
         data = JSON.pretty_generate([item])
 
-        if @index > 1 || append && File.exists?(path)
+        if @index > 1 || append && File.exist?(path)
           file_content = File.read(path).sub(/\}\n\]\Z/, "\}\,\n")
           File.open(path, "w") do |f|
             f.write(file_content + data.sub(/\A\[\n/, ""))
@@ -68,7 +68,7 @@ module Tanakai
       def save_to_jsonlines(item)
         data = JSON.generate(item)
 
-        if @index > 1 || append && File.exists?(path)
+        if @index > 1 || append && File.exist?(path)
           File.open(path, "a") { |file| file.write("\n" + data) }
         else
           File.open(path, "w") { |file| file.write(data) }
@@ -78,7 +78,7 @@ module Tanakai
       def save_to_csv(item)
         data = flatten_hash(item)
 
-        if @index > 1 || append && File.exists?(path)
+        if @index > 1 || append && File.exist?(path)
           CSV.open(path, "a+", force_quotes: true) do |csv|
             csv << data.values
           end
@@ -102,5 +102,3 @@ module Tanakai
     end
   end
 end
-
-

--- a/lib/tanakai/cli.rb
+++ b/lib/tanakai/cli.rb
@@ -174,7 +174,7 @@ module Tanakai
     private
 
     def inside_project?
-      Dir.exists?("spiders") && File.exists?("./config/boot.rb")
+      Dir.exist?("spiders") && File.exist?("./config/boot.rb")
     end
   end
 end

--- a/lib/tanakai/cli/ansible_command_builder.rb
+++ b/lib/tanakai/cli/ansible_command_builder.rb
@@ -31,7 +31,7 @@ module Tanakai
           "--extra-vars", "ansible_python_interpreter=/usr/bin/python3"
         ]
 
-        if File.exists? "config/automation.yml"
+        if File.exist? "config/automation.yml"
           require 'yaml'
           if config = YAML.load_file("config/automation.yml").dig(@playbook)
             config.each { |key, value| @vars[key] = value unless @vars[key] }

--- a/lib/tanakai/cli/generator.rb
+++ b/lib/tanakai/cli/generator.rb
@@ -17,7 +17,7 @@ module Tanakai
 
       def generate_spider(spider_name, in_project:)
         spider_path = in_project ? "spiders/#{spider_name}.rb" : "./#{spider_name}.rb"
-        raise "Spider #{spider_path} already exists" if File.exists? spider_path
+        raise "Spider #{spider_path} already exist?" if File.exist? spider_path
 
         spider_class = to_spider_class(spider_name)
         create_file spider_path do

--- a/spec/tanakai/base_spec.rb
+++ b/spec/tanakai/base_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Tanakai::Base do 
+RSpec.describe Tanakai::Base do
   describe '.running?' do
     pending
   end
@@ -125,7 +125,6 @@ RSpec.describe Tanakai::Base do
       end
     end
   end
-
 
   describe '#add_event' do
     pending


### PR DESCRIPTION
### Description
Both `File::exists?` and `Dir.exists?` deprecated methods were removed in Ruby 3.2.

### Progress
- [x] Use `File.exist?` instead of the removed `File.exists?`
- [x] Formatting

### References
[`File.exists?` deprecation](https://bugs.ruby-lang.org/issues/17391)
[Ruby 3.2 release notes](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/) see "Removed methods" section