### PR TITLE
Bug Fix: Add 'open-uri'

### DIFF
--- a/lib/tanakai/base.rb
+++ b/lib/tanakai/base.rb
@@ -1,7 +1,6 @@
 require_relative 'base/saver'
 require_relative 'base/storage'
 require 'addressable/uri'
-require 'open-uri'
 
 module Tanakai
   class Base
@@ -193,7 +192,9 @@ module Tanakai
     end
 
     def request_to(handler, delay = nil, url:, data: {}, response_type: :html)
-      raise InvalidUrlError, "Requested url is invalid: #{url}" unless URI.parse(url).kind_of?(URI::HTTP)
+      if %w[http https].exclude?(Addressable::URI.parse(url).scheme)
+        raise InvalidUrlError, "Requested url scheme is invalid: #{url}"
+      end
 
       if @config[:skip_duplicate_requests] && !unique_request?(url)
         add_event(:duplicate_requests) if self.with_info

--- a/lib/tanakai/base.rb
+++ b/lib/tanakai/base.rb
@@ -1,6 +1,7 @@
 require_relative 'base/saver'
 require_relative 'base/storage'
 require 'addressable/uri'
+require 'open-uri'
 
 module Tanakai
   class Base

--- a/spec/tanakai/base_spec.rb
+++ b/spec/tanakai/base_spec.rb
@@ -64,7 +64,56 @@ RSpec.describe Tanakai::Base do
   end
 
   describe '#request_to' do
-    pending
+    before do
+      def subject.ping(*); end
+      allow(subject).to receive(:browser).and_return(double(visit: true, current_response: :ok))
+    end
+
+    context 'when uri is missing' do
+      let(:url) { 'http://example.com' }
+
+      it  do
+        expect { subject.request_to(:ping, url: nil, data: {}) }.to raise_error NoMethodError
+      end
+    end
+
+    context 'when uri is valid' do
+      context 'when uri scheme is http' do
+        let(:url) { 'http://hello-world.com' }
+
+        it { expect { subject.request_to(:ping, url: url, data: {}) }.not_to raise_error }
+      end
+
+      context 'when uri scheme is https' do
+        let(:url) { 'https://hello-world.com' }
+
+        it { expect { subject.request_to(:ping, url: url, data: {}) }.not_to raise_error }
+      end
+
+      context 'when uri scheme is ftp' do
+        let(:url) { 'ftp://hello-world.com' }
+
+        it { expect { subject.request_to(:ping, url: url, data: {}) }.to raise_error described_class::InvalidUrlError }
+      end
+
+      context 'when uri scheme is file' do
+        let(:url) { 'file://hello-world.com' }
+
+        it { expect { subject.request_to(:ping, url: url, data: {}) }.to raise_error described_class::InvalidUrlError }
+      end
+
+      context 'when uri scheme is missing' do
+        let(:url) { '//hello-world.com' }
+
+        it { expect { subject.request_to(:ping, url: url, data: {}) }.to raise_error described_class::InvalidUrlError }
+      end
+    end
+
+    context 'when url is invalid' do
+      let(:url) { '[]' }
+
+      it { expect { subject.request_to(:ping, url: url, data: {}) }.to raise_error described_class::InvalidUrlError }
+    end
   end
 
   describe '#console' do


### PR DESCRIPTION
### Description
After running a simple spider, `uninitialized constant URI::HTTP (NameError)` error get's raised.


#### Steps to reproduce

> Simple crawler
```ruby
# test.rb

require 'tanakai'

class TestSpider < Tanakai::Base
  @name = 'test_spider'
  @engine = :selenium_firefox

  def parse(response, url:, **)
    puts response
    puts url
  end
end

TestSpider.parse!(:parse, url: 'http://example.com')
# same with `TestSpider.crawl!` and @start_urls = [...] defined
```

> Run as described in the README
```bash
$ bundle exec tanakai --version
1.7.1

$ bundle exec ruby test.rb
/home/alter-eon/projects/local_send_0/.bundle/ruby/3.2.0/gems/tanakai-1.7.1/lib/tanakai/base.rb:195:in `request_to': uninitialized constant URI::HTTP (NameError)

raise InvalidUrlError, "Requested url is invalid: #{url}" unless URI.parse(url).kind_of?(URI::HTTP)
^^^^^^
from /home/alter-eon/projects/local_send_0/.bundle/ruby/3.2.0/gems/tanakai-1.7.1/lib/tanakai/base.rb:163:in `parse!'
from test.rb:14:in `<main>'
```

#### Discussion
The problematic line is here: 
https://github.com/glaucocustodio/tanakai/blob/23a59af5ca8d165b36c3bb1553c57ec77121d094/lib/tanakai/base.rb#L195

I saw that the [addressable gem](https://github.com/sporkmonger/addressable) is used to handle URI manipulation. All of it is done in the [`lib/tanakai/base_helper.rb`](https://github.com/mrchriss/tanakai/blob/fix/add_open_uri/lib/tanakai/base_helper.rb)
[addressable gem](https://github.com/sporkmonger/addressable) was introduced as part of this commit: [add support to ruby 3 commit](https://github.com/glaucocustodio/tanakai/commit/0becb7f98fc2715441625c025264dab7b91bd198)

It seems like the `addressable/uri` gem does not include `URI::HTTP`, hence the error.
Note how the ancestor chain changes once [`open-uri`](https://github.com/ruby/open-uri) gets added:

```ruby
irb(#<TestSpider:0x00007f18544ed6d0>):003:0> url
=> "http://example.com"


irb(#<TestSpider:0x00007f18544ed6d0>):011:0> URI.parse(url).class.ancestors
=>
[URI::Generic,
 URI,
 URI::RFC2396_REGEXP,
 ActiveSupport::ToJsonWithActiveSupportEncoder,
 Object,
 PP::ObjectMixin,
 ActiveSupport::Tryable,
 JSON::Ext::Generator::GeneratorMethods::Object,
 Kernel,
 BasicObject]
 
 
irb(#<TestSpider:0x00007f18544ed6d0>):012:0> require 'open-uri'
=> true


irb(#<TestSpider:0x00007f18544ed6d0>):013:0> URI.parse(url).class.ancestors
=>
[URI::HTTP, # <<<========================== URI::HTTP appears
 OpenURI::OpenRead, #  <<<================= OpenURI::OpenRead appears
 URI::Generic, # |========================== rest stays the same
 URI,
 URI::RFC2396_REGEXP,
 ActiveSupport::ToJsonWithActiveSupportEncoder,
 Object,
 PP::ObjectMixin,
 ActiveSupport::Tryable,
 JSON::Ext::Generator::GeneratorMethods::Object,
 Kernel,
 BasicObject]
```

#### Solution
1. ~The simplest solution is to add [`open-uri`](https://github.com/ruby/open-uri) to [`lib/tanakai/base.rb`](https://github.com/MrChriss/tanakai/blob/fix/add_open_uri/lib/tanakai/base.rb)~ Won't do

2. ~Alternative solution would be to achieve the same functionality that the [addressable gem](https://github.com/sporkmonger/addressable) provides with [`open-uri`](https://github.com/ruby/open-uri). Though with being relatively new to the project and the lack of specs, I'm not confident doing that.~ Won't do

3. Check uri scheme with [addressable gem](https://github.com/sporkmonger/addressable); `http` and `https` schemes should be supported.

4. Other

### Progress
- [ ] ~require `open-uri` in [`lib/tanakai/base.rb`](https://github.com/MrChriss/tanakai/blob/fix/add_open_uri/lib/tanakai/base.rb)~
- [x] Check uri scheme directly with [addressable gem](https://github.com/sporkmonger/addressable), remove `open-uri` 
- [x] Add specs

### References
N/A