### PR TITLE
fix cuprite error when using root user in docker

### DIFF
--- a/lib/tanakai/browser_builder/cuprite_builder.rb
+++ b/lib/tanakai/browser_builder/cuprite_builder.rb
@@ -17,6 +17,7 @@ module Tanakai::BrowserBuilder
       # Register driver
       Capybara.register_driver :cuprite do |app|
         driver_options = { headless: ENV.fetch("HEADLESS", "true") == "true" }
+        driver_options[:browser_options] =  {'no-sandbox': nil} if Process.uid == 0 # root user
         logger.debug "BrowserBuilder (cuprite): enabled extensions"
 
         Capybara::Cuprite::Driver.new(app, driver_options)


### PR DESCRIPTION
When using cuprite engine in Docker using root user, got an error:
```
Ferrum::ProcessTimeoutError: Browser did not produce websocket url within 10 seconds, try to increase `:process_timeout`. See https://github.com/rubycdp/ferrum#customization (Ferrum::ProcessTimeoutError)
```

Fixed this by adding `browser_options: { 'no-sandbox': nil }` for root user based on Ferrum document: https://github.com/rubycdp/ferrum#docker  .