### PR TITLE
Add profiles to selenium_firefox engine.

### DIFF
--- a/lib/tanakai/browser_builder/selenium_firefox_builder.rb
+++ b/lib/tanakai/browser_builder/selenium_firefox_builder.rb
@@ -27,6 +27,13 @@ module Tanakai::BrowserBuilder
         driver_options.profile["browser.link.open_newwindow"] = 3 # open windows in tabs
         driver_options.profile["media.peerconnection.enabled"] = false # disable web rtc
 
+        # Profile
+        if @config[:profile].present?
+          @config[:profile].each do |key, value|
+            driver_options.profile[key] = value
+          end
+        end
+
         # Proxy
         if proxy = @config[:proxy].presence
           proxy_string = (proxy.class == Proc ? proxy.call : proxy).strip

--- a/spec/tanakai/base_spec.rb
+++ b/spec/tanakai/base_spec.rb
@@ -178,4 +178,37 @@ RSpec.describe Tanakai::Base do
   describe '#add_event' do
     pending
   end
+
+
+  describe '#selenium_firefox_save_pdf' do
+    class PDFTest < Tanakai::Base
+      @engine = :selenium_firefox
+      @start_urls = ['https://www.w3.org/TR/WCAG20-TECHS/PDF6.html']
+      @config = {
+        profile: {
+          "pdfjs.disabled" => true,
+          "browser.download.panel.shown" => false,
+          "default_content_settings.popups" => 0,
+          "browser.download.folderList" => 2,
+          "browser.download.dir" => "/tmp/pdfs",
+          "browser.helperApps.neverAsk.saveToDisk" => "application/pdf",
+          "browser.download.manager.showWhenStarting" => false,
+          "browser.download.useDownloadDir" => true,
+          "browser.helperApps.neverAsk.openFile" => "application/pdf"
+        }
+      }
+      def parse(response, url:, data: {})
+        #add_event "Try to click the pdf link"
+        browser.find(:xpath, "//a[contains(text(), 'working example of tagged table headings in Acrobat')]").click
+      end
+    end
+
+    context "when the pdf link was clicked" do
+      it "download the file into download folder" do
+        PDFTest.crawl!
+        expect(File.exist?("/tmp/pdfs/table-example-repaired.pdf")).to be true
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
Add the posibility to create custom profile using the selenium_firefox engine.

This allow to disable pdfjs and download pdfs when are clicked instead of showing in in a new tab.
Fix https://github.com/glaucocustodio/tanakai/issues/15
```
  @engine = :selenium_firefox
  @config = {
    encoding: "UTF-8",
    profile: {
      "pdfjs.disabled" => true,
      "browser.download.panel.shown" => false,
      "default_content_settings.popups" => 0,
      "browser.download.folderList" => 2,
      "browser.download.dir" => "/app/pdfs",
      "browser.helperApps.neverAsk.saveToDisk" => "application/pdf",
      "browser.download.manager.showWhenStarting" => false,
      "browser.download.useDownloadDir" => true,
      "browser.helperApps.neverAsk.openFile" => "application/pdf"
    }
  }
  ...
  browser.find(:xpath, "//a[contains(text(),\"#{pdfname}\")]").click
```